### PR TITLE
Fixes to necessary status fields in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ The `apiroute` is used for two main calls: Get from the thermostat and set the t
 {
     "targetTemperature":18,
     "temperature":"21.40",
-    "humidity":"69.20"
+    "humidity":"69.20",
+    "currentHeatingCoolingState": 6, # Pinned to AUTO
+    "targetState": "AUTO",
+    "targetStateCode": 6 # Pinned to AUTO
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ The `apiroute` is used for two main calls: Get from the thermostat and set the t
     "targetTemperature":18,
     "temperature":"21.40",
     "humidity":"69.20",
-    "currentHeatingCoolingState": 6, # Pinned to AUTO
-    "targetState": "AUTO",
-    "targetStateCode": 6 # Pinned to AUTO
+    "currentHeatingCoolingState": 1, # Pinned to HEAT
+    "targetState": "HEAT",
+    "targetStateCode": 1 # Pinned to AUTO
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ The `apiroute` is used for two main calls: Get from the thermostat and set the t
 }
 ```
 
-2. GET `/targettemperature/{FLOAT_VALUE}`
+2. GET `/targetTemperature/{FLOAT_VALUE}`


### PR DESCRIPTION
This caused my implemenation of https://hub.docker.com/r/jharmn/docker-homebridge-homeassistant to get 404s:

    192.168.1.54 - - [27/Nov/2016 19:21:21] "GET /targetTemperature/19 HTTP/1.1" 404 -

One more issue, second commit:

Turns out, HomeKit constantly says the thermostat isn't responding without the state variables, and eventually shows it as off. It probably works, but it's definitely confusing. I simply hardcoded these variables in my API implementation (along with `humidity: 0`, in case it was an issue). I dug these values out of your disabled code for changing heating/cooling state.