### PR TITLE
Remove min and max temperature for CurrentTemperature

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,9 +271,7 @@ Thermostat.prototype = {
 
 		this.service.getCharacteristic(Characteristic.CurrentTemperature)
 			.setProps({
-				minValue: this.minTemp,
-				maxValue: this.maxTemp,
-				minStep: 0.5
+				minStep: 0.1
 			});
 
 		this.service.getCharacteristic(Characteristic.TargetTemperature)


### PR DESCRIPTION
The Min and Max values should not be set for CurrentTemperature, but only for TargetTemperature. If you set it, and the real temperature is under or above thies values, Home will not show the real temperature in the room.
You can also reduce the step to 0.1 for this temperature to be more accurate.